### PR TITLE
No-Ticket Pipx is now installed by mise.

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
 gcc-arm-none-eabi = "14.2.Rel1"
 make = "4.4.1"
+pipx = "1.8.0"
 "pipx:makefile2dot" = "latest"


### PR DESCRIPTION
Pipx, which is needed for project setup, is now installed by mise.